### PR TITLE
nodemanager service script fails on Suse

### DIFF
--- a/templates/nodemanager.erb
+++ b/templates/nodemanager.erb
@@ -31,7 +31,12 @@
 if test -f /lib/lsb/init-functions; then
     . /lib/lsb/init-functions
 fi
+
+<% if osfamily == "Suse" %>
+. /etc/rc.status
+<% else %>
 . /etc/init.d/functions
+<% end %>
 
 # set NodeManager environment
 NodeManagerLockFile=<%= @nodeMgrLckFile %>


### PR DESCRIPTION
By default  the nodemanger script is using "/etc/init.d/functions" this
does not exists on Suse. Instead /etc/rc.status is used.
