### PR TITLE
[nodemanagerautostart] Add scriptname in default case of case statement

### DIFF
--- a/manifests/nodemanagerautostart.pp
+++ b/manifests/nodemanagerautostart.pp
@@ -41,6 +41,7 @@ define orautils::nodemanagerautostart(
     default: {
       $nodeMgrPath    = "${wl_home}/common/nodemanager"
       $nodeMgrBinPath = "${wl_home}/server/bin"
+      $scriptName     = "nodemanager"
 
       if $log_dir == undef {
         $nodeMgrLckFile = "${nodeMgrPath}/nodemanager.log.lck"


### PR DESCRIPTION
All the others code paths set the `$scriptname` . It is also used further down the line. Therefore we set it in the default path as well.