### PR TITLE
Added $remote_fs to init script dependencies

### DIFF
--- a/templates/nodemanager.erb
+++ b/templates/nodemanager.erb
@@ -8,7 +8,7 @@
 #
 ### BEGIN INIT INFO
 # Provides: nodemgr nodemanager
-# Required-Start: $network $local_fs
+# Required-Start: $network $local_fs $remote_fs
 # Required-Stop:
 # Should-Start:
 # Should-Stop:


### PR DESCRIPTION
Added $remote_fs to init script dependencies, because it's not uncommon to have WLS installed on a remote fs. On top of that, even basic pathes like /usr can be on a remote fs.