### PR TITLE
Suse: update-rc.d missing

### DIFF
--- a/manifests/nodemanagerautostart.pp
+++ b/manifests/nodemanagerautostart.pp
@@ -109,7 +109,17 @@ define orautils::nodemanagerautostart(
         }
       }
     }
-    'Ubuntu', 'Debian', 'SLES':{
+    'SLES':{
+        exec { "chkconfig ${scriptName}":
+          command   => "chkconfig --add ${scriptName}",
+          require   => File[$location],
+          user      => 'root',
+          unless    => "chkconfig | /bin/grep '${scriptName}'",
+          path      => $execPath,
+          logoutput => true,
+        }
+    }
+    'Ubuntu', 'Debian':{
       exec { "update-rc.d ${scriptName}":
         command   => "update-rc.d ${scriptName} defaults",
         require   => File[$location],


### PR DESCRIPTION
SuSE EE does not have update-rc.d command. Replace with chkconfig
command