### PR TITLE
Allow a custom location of the nodemanager script to be specified

### DIFF
--- a/manifests/nodemanagerautostart.pp
+++ b/manifests/nodemanagerautostart.pp
@@ -13,6 +13,7 @@ define orautils::nodemanagerautostart(
   $custom_trust              = false,
   $trust_keystore_file       = undef,
   $trust_keystore_passphrase = undef,
+  $custom_script_dir         = undef,
 ){
   case $version {
     1036, 1111, 1211 :{
@@ -57,7 +58,9 @@ define orautils::nodemanagerautostart(
     $trust_env = ''
   }
 
-  if ($::operatingsystem in ['CentOS','RedHat','OracleLinux'] and $::operatingsystemmajrelease == '7') {
+  if $custom_script_dir {
+    $location = "${custom_script_dir}/${scriptName}"
+  } elsif ($::operatingsystem in ['CentOS','RedHat','OracleLinux'] and $::operatingsystemmajrelease == '7') {
     $location = "/home/${user}/${scriptName}"
   } else {
     $location = "/etc/init.d/${scriptName}"

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -4,8 +4,8 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-ExecStart=/home/<%= @user %>/<%= @scriptName %> start
-ExecStop=/home/<%= @user %>/<%= @scriptName %> stop
+ExecStart=<%= @location %> start
+ExecStop=<%= @location %> stop
 TimeoutSec=30
 KillMode=process
 RemainAfterExit=yes


### PR DESCRIPTION
Hey, 

I've added the ability to override the location of the script by adding a class parameter custom_script_dir and setting `$location` to `"${custom_script_dir}/${scriptName}"`. This doesn't create the custom directory, that should be handled by the user. 

This will allow the script to be placed anywhere the user specifies and fallback to the default behaviour which is probably fine for most users. 

Thanks, 

Tim. 